### PR TITLE
fix: add no-sandbox flag to scrapper

### DIFF
--- a/scrapper/index.ts
+++ b/scrapper/index.ts
@@ -10,8 +10,11 @@ import { bootstrapOutput } from './services/writer';
   bootstrapOutput();
 
   const browser = await puppeteer.launch({
-    headless: true,
+    headless: false,
     ignoreHTTPSErrors: true,
+    args: [
+      '--no-sandbox',
+    ],
   });
 
   try {


### PR DESCRIPTION
## Overview

This pull request adds `--no-sandbox` flag to puppeteer scrapper to make sure that it runs on cloud deployment platform.